### PR TITLE
Fix dark variant with custom variant

### DIFF
--- a/packages/catppuccin-tailwindcss/package.json
+++ b/packages/catppuccin-tailwindcss/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "prepare": "pnpm run build",
     "build": "sass -I node_modules --no-source-map src:./",
+    "postbuild": "sed --in-place '/@variant dark {/{N; s/@variant dark {\\n[[:space:]]*:root {/:root {\\n    @variant dark {/}' *.css",
     "watch": "sass -I node_modules --no-source-map --watch --update --style=expanded src:./"
   },
   "files": [


### PR DESCRIPTION
Closes #37.

As discussed in [this comment](https://github.com/catppuccin/tailwindcss/issues/37#issuecomment-3719832131), sass outputs the `@variant dark` and `:root` blocks in the wrong order. To fix this, I added a `postbuild` script to the package that uses `sed` to swap these lines. It's not the most elegant solution, and it doesn't work with the `watch` script, but it's the best I could come up with.